### PR TITLE
#75 fix cleanup ops

### DIFF
--- a/linguine/operation_builder.py
+++ b/linguine/operation_builder.py
@@ -10,12 +10,13 @@ from linguine.ops.remove_caps import RemoveCapsPreserveNNP
 from linguine.ops.remove_punct import RemovePunct
 from linguine.ops.remove_stopwords import RemoveStopwords
 from linguine.ops.sentence_tokenize import SentenceTokenize
-from linguine.ops.stem import StemmerLancaster, StemmerPorter, StemmerSnowball
+from linguine.ops.stem import StemmerPorter
 from linguine.ops.topic_model import TopicModel
 from linguine.ops.word_tokenize import WordTokenizeTreebank, WordTokenizeWhitespacePunct, WordTokenizeStanford, WordTokenizeSpaces, WordTokenizeTabs
 from linguine.ops.StanfordCoreNLP import StanfordCoreNLP
 
 def get_operation_handler(operation):
+    print(operation)
     if operation == 'lemmatize_wordnet':
         return LemmatizerWordNet()
     elif operation == 'pos_tag':

--- a/linguine/ops/lemmatize.py
+++ b/linguine/ops/lemmatize.py
@@ -15,10 +15,16 @@ class LemmatizerWordNet:
             tags = pos_tag(corpus.tokenized_contents)
             lemmatizer = WordNetLemmatizer()
             corpus.tokenized_contents = [lemmatizer.lemmatize(word, self.getWordNetPartOfSpeech(tag)) 
-                                            if not self.getWordNetPartOfSpeech(tag) == None 
-                                            else word 
-                                            for (word,tag) in tags]
-            corpus.contents = ''.join(corpus.tokenized_contents)
+                    if not self.getWordNetPartOfSpeech(tag) == None 
+                    else word 
+                    for (word,tag) in tags]
+
+            corpusString = ""
+            for index, word in enumerate(corpus.tokenized_contents):
+                corpusString += corpus.tokenized_contents[index] + " "
+
+            corpus.contents = corpusString
+
         return data
     def getWordNetPartOfSpeech(self,treebank_tag):
         #So the WordNetLemmatizer in NLTK expects POS tags in a different format than NLTK itself writes them. 

--- a/linguine/ops/stem.py
+++ b/linguine/ops/stem.py
@@ -5,8 +5,6 @@ Given: A list of strings representing a tokenized collection of words.
 There are three stemming algorithms available: The Porter stemmer,
 the Lancaster stemmer, and the Snowball stemmer.
 """
-from nltk.stem.snowball import EnglishStemmer
-from nltk.stem.lancaster import LancasterStemmer
 from nltk.stem.porter import PorterStemmer
 class StemmerPorter:
     def __init__(self):
@@ -19,7 +17,6 @@ class StemmerPorter:
             for index, word in enumerate(corpus.tokenized_contents):
                 corpusString += corpus.tokenized_contents[index] + " "
             
-            print(corpusString)
             corpus.contents = corpusString
 
         return data

--- a/linguine/ops/stem.py
+++ b/linguine/ops/stem.py
@@ -8,30 +8,18 @@ the Lancaster stemmer, and the Snowball stemmer.
 from nltk.stem.snowball import EnglishStemmer
 from nltk.stem.lancaster import LancasterStemmer
 from nltk.stem.porter import PorterStemmer
-class StemmerSnowball:
-    def __init__(self):
-        pass
-    def run(self, data):
-        english = EnglishStemmer()
-        for corpus in data:
-            corpus.tokenized_contents = [english.stem(word) for word in corpus.tokenized_contents]
-            corpus.contents = ''.join(corpus.tokenized_contents)
-        return data
-class StemmerLancaster:
-    def __init__(self):
-        pass
-    def run(self, data):
-        lancaster = LancasterStemmer()
-        for corpus in data:
-            corpus.tokenized_contents = [lancaster.stem(word) for word in corpus.tokenized_contents]
-            corpus.contents = ''.join(corpus.tokenized_contents)
-        return data
 class StemmerPorter:
     def __init__(self):
         pass
     def run(self, data):
         porter = PorterStemmer()
         for corpus in data:
+            corpusString = ""
             corpus.tokenized_contents = [porter.stem(word) for word in corpus.tokenized_contents]
-            corpus.contents = ''.join(corpus.tokenized_contents)
+            for index, word in enumerate(corpus.tokenized_contents):
+                corpusString += corpus.tokenized_contents[index] + " "
+            
+            print(corpusString)
+            corpus.contents = corpusString
+
         return data

--- a/linguine/transaction.py
+++ b/linguine/transaction.py
@@ -20,7 +20,6 @@ class Transaction:
         self.cleanups = []
         self.tokenizer = None
 
-        #TOKENIZER LIST: If a new operation requires a user-selected tokenizer, add it here
         self.token_based_operations = ['tfidf','word_cloud_op','stem_porter','stem_lancaster','stem_snowball','lemmatize_wordnet']
 
     def parse_json(self, json_data):
@@ -56,15 +55,22 @@ class Transaction:
         tokenized_corpora = []
         analysis = {}
         
-        for cleanup in self.cleanups:
-            op_handler = linguine.operation_builder.get_operation_handler(cleanup)
-            corpora = op_handler.run(corpora)
-        
         if not self.tokenizer == None and not self.tokenizer == '':
             op_handler = linguine.operation_builder \
             .get_operation_handler(self.tokenizer)
-
             tokenized_corpora = op_handler.run(corpora)
+        
+        for cleanup in self.cleanups:
+
+            op_handler = linguine.operation_builder.\
+            get_operation_handler(cleanup)
+            corpora = op_handler.run(corpora)
+            
+            #Corpora must be re tokenized after each cleanup
+            if not self.tokenizer == None and not self.tokenizer == '':
+              op_handler = linguine.operation_builder \
+              .get_operation_handler(self.tokenizer)
+              tokenized_corpora = op_handler.run(corpora)
 
         op_handler = linguine.operation_builder.get_operation_handler(self.operation)
 

--- a/linguine/transaction.py
+++ b/linguine/transaction.py
@@ -56,18 +56,19 @@ class Transaction:
         tokenized_corpora = []
         analysis = {}
         
-        if not self.tokenizer == None and not self.tokenizer == '':
-            op_handler = linguine.operation_builder.get_operation_handler(self.tokenizer)
-            tokenized_corpora = op_handler.run(corpora)
         for cleanup in self.cleanups:
             op_handler = linguine.operation_builder.get_operation_handler(cleanup)
             corpora = op_handler.run(corpora)
+        
+        if not self.tokenizer == None and not self.tokenizer == '':
+            op_handler = linguine.operation_builder \
+            .get_operation_handler(self.tokenizer)
+
+            tokenized_corpora = op_handler.run(corpora)
+
         op_handler = linguine.operation_builder.get_operation_handler(self.operation)
 
         if self.operation in self.token_based_operations:
-            if self.tokenizer == None:
-                tokenizer_handler = linguine.operation_builder.get_operation_handler('word_tokenize_spaces')
-                tokenized_corpora = tokenizer_handler.run(corpora)
             analysis = {'user_id':ObjectId(self.user_id),
                         'analysis_name': self.analysis_name,
                         'corpora_ids':self.corpora_ids,
@@ -81,7 +82,9 @@ class Transaction:
                         'cleanup_ids':self.cleanups,
                         'result':op_handler.run(corpora),
                         'analysis':self.operation}
+
         analysis_id = DatabaseAdapter.getDB().analyses.insert(analysis)
+
         response = {'transaction_id': self.transaction_id,
                     'cleanup_ids': self.cleanups,
                     'library':self.library,


### PR DESCRIPTION
No cleanup options were being sent to the backend, and once they were due to updates in linguine-node,  a good majority of them were broken. There were a few changes made to ensure each cleanup task works.: 

Changelog 
--
* For stemming and lemmatization, tokenized contents were being combined back together without spaces, leading to sentenceslikethisbeingtreatedaswords. 

* When a cleanup option that required tokenization to work (such as stemming) was run, the corpus text was overwritten with the tokenized contents, thus overwriting all other previous cleanups that were run. An example would be tokenizing a body of text and then running a remove caps cleanup on it, the results were not showing that the cleanup step happened. In order to mitigate this tokenization is now redone whenever a new cleanup task is done in the analysis pipeline. 
