### PR TITLE
Remove Stop Words

### DIFF
--- a/linguine/operation_builder.py
+++ b/linguine/operation_builder.py
@@ -38,6 +38,8 @@ def get_operation_handler(operation):
         return StemmerLancaster()
     elif operation == 'stem_snowball':
         return StemmerSnowball()
+    elif operation == 'stop_words':
+        return RemoveStopwords()
     elif operation == 'tfidf':
         return Tfidf()
     elif operation == 'topic_model':


### PR DESCRIPTION
Common articles like and, or, and but are apparently called "stop words".  So, apparently this was already set up by the last team, so all I had to do was hook it through our operation_builder...